### PR TITLE
chapter_10/Makefile: fix issue with libglade not finding signal handlers

### DIFF
--- a/chapter_10/Makefile
+++ b/chapter_10/Makefile
@@ -1,6 +1,6 @@
 EXES = browser
 CC = cc
-CFLAGS = -Wall -g `pkg-config --cflags --libs gtk+-2.0 libglade-2.0`
+CFLAGS = -Wl,--export-dynamic -Wall -g `pkg-config --cflags --libs gtk+-2.0 libglade-2.0`
 
 all: 
 	$(MAKE) $(EXES)


### PR DESCRIPTION
This:
libglade-WARNING **: could not find signal handler 'on_row_activated'.